### PR TITLE
Docker - Fixed missing dependencies and added a missing path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM openjdk:7-jdk-alpine
-RUN mkdir /opt/ && \
+RUN mkdir -p /opt/gtfs-editor/public/data && \
     cd /opt/ && \
-    mkdir /opt/gtfs-editor && \
     apk add --update --no-cache python && \
     wget http://downloads.typesafe.com/releases/play-1.2.5.zip && \
     jar xf play-1.2.5.zip && \

--- a/conf/dependencies.yml
+++ b/conf/dependencies.yml
@@ -15,6 +15,7 @@ require:
     - org.opentripplanner -> otp 0.14.0
     - net.sf.opencsv -> opencsv 2.0
     - org.mapdb -> mapdb 1.0.7
+    - javax.media -> jai_core 1.1.3
     
     
 repositories:
@@ -28,6 +29,14 @@ repositories:
         root: "http://download.osgeo.org/webdav/geotools/"
         contains:
             - org.geotools -> *
+            - jgridshift -> *
+            - java3d -> *
+            - javax.media -> *
+    - akka:
+        type: iBiblio
+        root: "http://repo.akka.io/releases/"
+        contains:
+            - voldemort.store.compress -> *
 
     - conveyal:
         type: iBiblio


### PR DESCRIPTION
I have added some missing dependencies that play couldn't find.

Also, I have created a missing directory that gtfs-editor try to use when the user exports GTFS or GIS data.

Finally, while trying to export as GTFS I got a jvm heap space out of memory error that can be fixed by removing the -Xmx java option. I haven't included that change.

Thanks!